### PR TITLE
fix!: modify order price that cross the market price

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ quantityLeft - 4
  * Modify an existing order with given ID
  *
  * @param orderID - The ID of the order to be modified
- * @param orderUpdate - An object with the modified size and/or price of an order. To be note that the `side` can't be modified. The shape of the object is `{side, size, price}`.
+ * @param orderUpdate - An object with the modified size and/or price of an order. The shape of the object is `{size?: number, price?: number}`.
  * @returns The modified order if exists or `undefined`
  */
-modify(orderID: string, { side: 'buy' | 'sell', size: number, price: number });
+modify(orderID: string, { size: number, price: number });
 ```
 
 For example:
@@ -206,7 +206,7 @@ bids: 90  -> 5      90  -> 5
       80  -> 1      80  -> 1
 
 // Modify the size from 55 to 65
-modify("uniqueID", { side: "sell", size: 65, price: 100 })
+modify("uniqueID", { size: 65 })
 
 asks: 110 -> 5      110 -> 5
       100 -> 56     100 -> 66
@@ -216,7 +216,7 @@ bids: 90  -> 5      90  -> 5
 
 
 // Modify the price from 100 to 110
-modify("uniqueID", { side: "sell", size: 65, price: 110 })
+modify("uniqueID", { price: 110 })
 
 asks: 110 -> 5      110 -> 70
       100 -> 66     100 -> 1

--- a/src/order.ts
+++ b/src/order.ts
@@ -10,11 +10,8 @@ interface IOrder {
   isMaker: boolean
 }
 
-export interface OrderUpdate {
-  side: Side
-  size?: number
-  price?: number
-}
+export interface OrderUpdatePrize { price: number, size?: number }
+export interface OrderUpdateSize { price?: number, size: number }
 
 export enum OrderType {
   LIMIT = 'limit',
@@ -31,7 +28,7 @@ export class Order {
   private readonly _id: string
   private readonly _side: Side
   private _size: BigNumber
-  private readonly _price: number
+  private _price: number
   private _time: number
   private readonly _isMaker: boolean
   constructor (
@@ -63,6 +60,11 @@ export class Order {
   // Getter for order price
   get price (): number {
     return this._price
+  }
+
+  // Getter for order price
+  set price (price: number) {
+    this._price = price
   }
 
   // Getter for order size

--- a/src/order.ts
+++ b/src/order.ts
@@ -10,7 +10,7 @@ interface IOrder {
   isMaker: boolean
 }
 
-export interface OrderUpdatePrize { price: number, size?: number }
+export interface OrderUpdatePrice { price: number, size?: number }
 export interface OrderUpdateSize { price?: number, size: number }
 
 export enum OrderType {

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { ERROR, CustomError } from './errors'
-import { Order, OrderType, OrderUpdatePrize, OrderUpdateSize, TimeInForce } from './order'
+import { Order, OrderType, OrderUpdatePrice, OrderUpdateSize, TimeInForce } from './order'
 import { OrderQueue } from './orderqueue'
 import { OrderSide } from './orderside'
 import { Side } from './side'
@@ -279,7 +279,7 @@ export class OrderBook {
    */
   public modify = (
     orderID: string,
-    orderUpdate: OrderUpdatePrize | OrderUpdateSize
+    orderUpdate: OrderUpdatePrice | OrderUpdateSize
   ): Order | undefined => {
     const order = this.orders[orderID]
     if (order === undefined) return

--- a/src/orderside.ts
+++ b/src/orderside.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import createRBTree from 'functional-red-black-tree'
 import { CustomError, ERROR } from './errors'
-import { Order, OrderUpdatePrize, OrderUpdateSize } from './order'
+import { Order, OrderUpdatePrice, OrderUpdateSize } from './order'
 import { OrderQueue } from './orderqueue'
 import { Side } from './side'
 
@@ -88,7 +88,7 @@ export class OrderSide {
   // Update the price of an order and return the order with the updated price
   updateOrderPrice = (
     oldOrder: Order,
-    orderUpdate: OrderUpdatePrize
+    orderUpdate: OrderUpdatePrice
   ): Order => {
     this.remove(oldOrder)
     const newOrder = new Order(

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -50,7 +50,6 @@ void test('it should create order without passing a date', ({
 }) => {
   const fakeTimestamp = 1487076708000
   const { now } = Date
-  // @ts-expect-error
   teardown(() => (Date.now = now))
   Date.now = (...m) => fakeTimestamp
 
@@ -96,4 +95,30 @@ void test('it should create order without passing a date', ({
     })
   )
   end()
+})
+
+void test('test orders setters', (t) => {
+  const id = 'fakeId'
+  const side = Side.BUY
+  const size = 5
+  const price = 100
+  const time = Date.now()
+  const order = new Order(id, side, new BigNumber(size), price, time)
+
+  // Price setter
+  const newPrice = 300
+  order.price = newPrice
+  t.equal(order.price, newPrice)
+
+  // Size setter
+  const newSize = new BigNumber(40)
+  order.size = newSize
+  t.equal(order.size.toNumber(), newSize.toNumber())
+
+  // Time setter
+  const newTime = Date.now()
+  order.time = newTime
+  t.equal(order.time, newTime)
+
+  t.end()
 })

--- a/test/orderside.test.ts
+++ b/test/orderside.test.ts
@@ -26,7 +26,11 @@ void test('it should append/update/remove orders from queue on BUY side', ({
   os.append(order2)
   equal(os.depth(), 2)
   equal(os.volume().toNumber(), 10)
-  equal(os.total().toNumber(), order1.price * order1.size.toNumber() + order2.price * order2.size.toNumber())
+  equal(
+    os.total().toNumber(),
+    order1.price * order1.size.toNumber() +
+      order2.price * order2.size.toNumber()
+  )
   equal(os.len(), 2)
   equal(os.priceTree().length, 2)
   same(os.orders()[0], order1)
@@ -43,7 +47,10 @@ void test('it should append/update/remove orders from queue on BUY side', ({
   equal(os.toString(), '\n20 -> 5\n10 -> 5')
 
   // Update order size and passing a price
-  os.update(order1, { side: order1.side, size: 10, price: order1.price })
+  os.updateOrderSize(order1, {
+    size: 10,
+    price: order1.price
+  })
 
   equal(os.volume().toNumber(), 15)
   equal(os.depth(), 2)
@@ -53,7 +60,7 @@ void test('it should append/update/remove orders from queue on BUY side', ({
   equal(os.toString(), '\n20 -> 5\n10 -> 10')
 
   // Update order size without passing price, so the old order price will be used
-  os.update(order1, { side: order1.side, size: 5 })
+  os.updateOrderSize(order1, { size: 5 })
 
   equal(os.volume().toNumber(), 10)
   equal(os.depth(), 2)
@@ -62,13 +69,9 @@ void test('it should append/update/remove orders from queue on BUY side', ({
   same(os.orders()[1], order2)
   equal(os.toString(), '\n20 -> 5\n10 -> 5')
 
-  // When no size or price don't do nothing
-  equal(os.update(order1, { side: order1.side }), undefined)
-
   // When price is updated a new order will be created, so we can't match entire object, only properties
   // Update price of order1 < price order2
-  let updatedOrder = os.update(order1, {
-    side: order1.side,
+  let updatedOrder = os.updateOrderPrice(order1, {
     size: 10,
     price: 15
   })
@@ -84,8 +87,7 @@ void test('it should append/update/remove orders from queue on BUY side', ({
   // Test for error when price level not exists
   try {
     // order1 has been replaced whit updateOrder, so trying to update order1 will throw an error of type ErrInvalidPriceLevel
-    os.update(order1, {
-      side: order1.side,
+    os.updateOrderPrice(order1, {
       size: 10,
       price: 20
     })
@@ -96,11 +98,10 @@ void test('it should append/update/remove orders from queue on BUY side', ({
     }
   }
 
-  // Update price of order1 == price order2
+  // Update price of order1 == price order2, without providind size (the original order size is used)
   // we have to type ignore here because we don't want to pass the size,
   // so the size from the oldOrder will be used instead
-  updatedOrder = os.update(updatedOrder as Order, {
-    side: order1.side,
+  updatedOrder = os.updateOrderPrice(updatedOrder, {
     price: 20
   })
   equal(os.volume().toNumber(), 15)
@@ -113,8 +114,7 @@ void test('it should append/update/remove orders from queue on BUY side', ({
   equal(os.toString(), '\n20 -> 15')
 
   // Update price of order1 > price order2
-  updatedOrder = os.update(updatedOrder as Order, {
-    side: order1.side,
+  updatedOrder = os.updateOrderPrice(updatedOrder, {
     size: 10,
     price: 25
   })
@@ -128,7 +128,7 @@ void test('it should append/update/remove orders from queue on BUY side', ({
   equal(os.toString(), '\n25 -> 10\n20 -> 5')
 
   // Remove the updated order
-  os.remove(updatedOrder as Order)
+  os.remove(updatedOrder)
 
   equal(os.maxPriceQueue(), os.minPriceQueue())
   equal(os.depth(), 1)
@@ -171,7 +171,11 @@ void test('it should append/update/remove orders from queue on SELL side', ({
   os.append(order2)
   equal(os.depth(), 2)
   equal(os.volume().toNumber(), 10)
-  equal(os.total().toNumber(), order1.price * order1.size.toNumber() + order2.price * order2.size.toNumber())
+  equal(
+    os.total().toNumber(),
+    order1.price * order1.size.toNumber() +
+      order2.price * order2.size.toNumber()
+  )
   equal(os.len(), 2)
   equal(os.priceTree().length, 2)
   same(os.orders()[0], order1)
@@ -188,7 +192,10 @@ void test('it should append/update/remove orders from queue on SELL side', ({
   equal(os.toString(), '\n20 -> 5\n10 -> 5')
 
   // Update order size and passing a price
-  os.update(order1, { side: order1.side, size: 10, price: order1.price })
+  os.updateOrderSize(order1, {
+    size: 10,
+    price: order1.price
+  })
 
   equal(os.volume().toNumber(), 15)
   equal(os.depth(), 2)
@@ -199,8 +206,7 @@ void test('it should append/update/remove orders from queue on SELL side', ({
 
   // When price is updated a new order will be created, so we can't match entire object, only properties
   // Update price of order1 < price order2
-  let updatedOrder = os.update(order1, {
-    side: order1.side,
+  let updatedOrder = os.updateOrderPrice(order1, {
     size: 10,
     price: 15
   })
@@ -216,8 +222,7 @@ void test('it should append/update/remove orders from queue on SELL side', ({
   // Test for error when price level not exists
   try {
     // order1 has been replaced whit updateOrder, so trying to update order1 will throw an error of type ErrInvalidPriceLevel
-    os.update(order1, {
-      side: order1.side,
+    os.updateOrderPrice(order1, {
       size: 10,
       price: 20
     })
@@ -231,8 +236,8 @@ void test('it should append/update/remove orders from queue on SELL side', ({
   // Update price of order1 == price order2
   // we have to type ignore here because we don't want to pass the size,
   // so the size from the oldOrder will be used instead
-  updatedOrder = os.update(updatedOrder as Order, {
-    side: order1.side,
+  updatedOrder = os.updateOrderPrice(updatedOrder, {
+    size: updatedOrder.size.toNumber(),
     price: 20
   })
   equal(os.volume().toNumber(), 15)
@@ -245,8 +250,7 @@ void test('it should append/update/remove orders from queue on SELL side', ({
   equal(os.toString(), '\n20 -> 15')
 
   // Update price of order1 > price order2
-  updatedOrder = os.update(updatedOrder as Order, {
-    side: order1.side,
+  updatedOrder = os.updateOrderPrice(updatedOrder, {
     size: 10,
     price: 25
   })
@@ -260,7 +264,7 @@ void test('it should append/update/remove orders from queue on SELL side', ({
   equal(os.toString(), '\n25 -> 10\n20 -> 5')
 
   // Remove the updated order
-  os.remove(updatedOrder as Order)
+  os.remove(updatedOrder)
 
   equal(os.maxPriceQueue(), os.minPriceQueue())
   equal(os.depth(), 1)


### PR DESCRIPTION
Refs: #336

BREAKING CHANGES: The `modify` function now accepts only `size` and/or `price` as update options. The `side` option was unnecessary since the side cannot be modified.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/fasenderos/hft-limit-order-book/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs (README.md) have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

```
limit("sell", "id1", 1, 200);
limit("buy", "id2", 1, 100);
modify("id2", { side: "buy", size: 1, price: 200})

Result:
asks: 200 -> 1
--------------  
bids: 200 -> 1
```

Issue Number: #336


## What is the new behavior?

```
limit("sell", "id1", 1, 200);
limit("buy", "id2", 1, 100);
modify("id2", { side: "buy", size: 1, price: 200})

Result: Empty order book
```

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
