### PR TITLE
Modify size under the price-time-priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,14 @@ quantityLeft - 4
 
 ```js
 /**
- * Modify an existing order with given ID
+ * Modify an existing order with given ID. When an order is modified by price or quantity,
+ * it will be deemed as a new entry. Under the price-time-priority algorithm, orders are
+ * prioritized according to their order price and order time. Hence, the latest orders
+ * will be placed at the back of the matching order queue.
  *
  * @param orderID - The ID of the order to be modified
- * @param orderUpdate - An object with the modified size and/or price of an order. The shape of the object is `{size?: number, price?: number}`.
- * @returns The modified order if exists or `undefined`
+ * @param orderUpdate - An object with the modified size and/or price of an order. The shape of the object is `{size, price}`.
+ * @returns An object with the result of the processed order or an error
  */
 modify(orderID: string, { size: number, price: number });
 ```

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,11 +4,13 @@ export enum ERROR {
   ErrInvalidOrderType = "orderbook: supported order type are 'limit' and 'market'",
   ErrInvalidPrice = 'orderbook: invalid order price',
   ErrInvalidPriceLevel = 'orderbook: invalid order price level',
+  ErrInvalidPriceOrQuantity = 'orderbook: invalid order price or quantity',
   ErrInvalidQuantity = 'orderbook: invalid order quantity',
   ErrInvalidSide = "orderbook: given neither 'bid' nor 'ask'",
   ErrInvalidTimeInForce = "orderbook: supported time in force are 'GTC', 'IOC' and 'FOK'",
   ErrLimitFOKNotFillable = 'orderbook: limit FOK order not fillable',
   ErrOrderExists = 'orderbook: order already exists',
+  ErrOrderNotFound = 'orderbook: order not found',
 }
 
 export const CustomError = (error?: ERROR | string): Error => {
@@ -21,8 +23,12 @@ export const CustomError = (error?: ERROR | string): Error => {
       return new Error(ERROR.ErrInvalidPrice)
     case ERROR.ErrInvalidPriceLevel:
       return new Error(ERROR.ErrInvalidPriceLevel)
+    case ERROR.ErrInvalidPriceOrQuantity:
+      return new Error(ERROR.ErrInvalidPriceOrQuantity)
     case ERROR.ErrOrderExists:
       return new Error(ERROR.ErrOrderExists)
+    case ERROR.ErrOrderNotFound:
+      return new Error(ERROR.ErrOrderNotFound)
     case ERROR.ErrInvalidSide:
       return new Error(ERROR.ErrInvalidSide)
     case ERROR.ErrInvalidOrderType:

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -91,7 +91,7 @@ export class OrderBook {
    * @returns An object with the result of the processed order or an error
    */
   public market = (side: Side, size: number): IProcessOrder => {
-    const response = this.responseShape(size)
+    const response = this.getProcessOrderResponse(size)
 
     if (![Side.SELL, Side.BUY].includes(side)) {
       response.err = CustomError(ERROR.ErrInvalidSide)
@@ -145,7 +145,7 @@ export class OrderBook {
     price: number,
     timeInForce: TimeInForce = TimeInForce.GTC
   ): IProcessOrder => {
-    const response = this.responseShape(size)
+    const response = this.getProcessOrderResponse(size)
 
     if (![Side.SELL, Side.BUY].includes(side)) {
       response.err = CustomError(ERROR.ErrInvalidSide)
@@ -205,7 +205,7 @@ export class OrderBook {
       const newPrice = orderUpdate.price ?? order.price
       const newSize = orderUpdate.size ?? order.size
       if (newPrice > 0 && newSize > 0) {
-        const response = this.responseShape(newSize)
+        const response = this.getProcessOrderResponse(newSize)
         this.cancel(order.id)
         this.createLimitOrder(
           response,
@@ -318,7 +318,7 @@ export class OrderBook {
     return { price, err }
   }
 
-  private readonly responseShape = (size: number): IProcessOrder => {
+  private readonly getProcessOrderResponse = (size: number): IProcessOrder => {
     return {
       done: [],
       partial: null,

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -1,5 +1,11 @@
 import { ERROR, CustomError } from './errors'
-import { Order, OrderType, OrderUpdatePrice, OrderUpdateSize, TimeInForce } from './order'
+import {
+  Order,
+  OrderType,
+  OrderUpdatePrice,
+  OrderUpdateSize,
+  TimeInForce
+} from './order'
 import { OrderQueue } from './orderqueue'
 import { OrderSide } from './orderside'
 import { Side } from './side'
@@ -85,15 +91,9 @@ export class OrderBook {
    * @returns An object with the result of the processed order or an error
    */
   public market = (side: Side, size: number): IProcessOrder => {
-    const response: IProcessOrder = {
-      done: [],
-      partial: null,
-      partialQuantityProcessed: 0,
-      quantityLeft: size,
-      err: null
-    }
+    const response = this.responseShape(size)
 
-    if (side !== Side.SELL && side !== Side.BUY) {
+    if (![Side.SELL, Side.BUY].includes(side)) {
       response.err = CustomError(ERROR.ErrInvalidSide)
       return response
     }
@@ -145,15 +145,9 @@ export class OrderBook {
     price: number,
     timeInForce: TimeInForce = TimeInForce.GTC
   ): IProcessOrder => {
-    const response: IProcessOrder = {
-      done: [],
-      partial: null,
-      partialQuantityProcessed: 0,
-      quantityLeft: size,
-      err: null
-    }
+    const response = this.responseShape(size)
 
-    if (side !== Side.SELL && side !== Side.BUY) {
+    if (![Side.SELL, Side.BUY].includes(side)) {
       response.err = CustomError(ERROR.ErrInvalidSide)
       return response
     }
@@ -178,184 +172,60 @@ export class OrderBook {
       return response
     }
 
-    let quantityToTrade = size
-    let sideToProcess: OrderSide
-    let sideToAdd: OrderSide
-    let comparator
-    let iter
-
-    if (side === Side.BUY) {
-      sideToAdd = this.bids
-      sideToProcess = this.asks
-      comparator = this.greaterThanOrEqual
-      iter = this.asks.minPriceQueue
-    } else {
-      sideToAdd = this.asks
-      sideToProcess = this.bids
-      comparator = this.lowerThanOrEqual
-      iter = this.bids.maxPriceQueue
-    }
-
-    if (timeInForce === TimeInForce.FOK) {
-      const fillable = this.canFillOrder(sideToProcess, side, size, price)
-      if (!fillable) {
-        response.err = CustomError(ERROR.ErrLimitFOKNotFillable)
-        return response
-      }
-    }
-
-    let bestPrice = iter()
-    while (
-      quantityToTrade > 0 &&
-      sideToProcess.len() > 0 &&
-      bestPrice !== undefined &&
-      comparator(price, bestPrice.price())
-    ) {
-      const { done, partial, partialQuantityProcessed, quantityLeft } =
-        this.processQueue(bestPrice, quantityToTrade)
-      response.done = response.done.concat(done)
-      response.partial = partial
-      response.partialQuantityProcessed = partialQuantityProcessed
-      quantityToTrade = quantityLeft
-      response.quantityLeft = quantityToTrade
-      bestPrice = iter()
-    }
-
-    if (quantityToTrade > 0) {
-      const order = new Order(
-        orderID,
-        side,
-        quantityToTrade,
-        price,
-        Date.now(),
-        true
-      )
-      if (response.done.length > 0) {
-        response.partialQuantityProcessed = size - quantityToTrade
-        response.partial = order
-      }
-      this.orders[orderID] = sideToAdd.append(order)
-    } else {
-      let totalQuantity = 0
-      let totalPrice = 0
-
-      response.done.forEach((order: Order) => {
-        totalQuantity += order.size
-        totalPrice += order.price * order.size
-      })
-      if (response.partialQuantityProcessed > 0 && response.partial !== null) {
-        totalQuantity += response.partialQuantityProcessed
-        totalPrice +=
-          response.partial.price * response.partialQuantityProcessed
-      }
-
-      response.done.push(
-        new Order(
-          orderID,
-          side,
-          size,
-          totalPrice / totalQuantity,
-          Date.now()
-        )
-      )
-    }
-
-    // If IOC order was not matched completely remove from the order book
-    if (timeInForce === TimeInForce.IOC && response.quantityLeft > 0) {
-      this.cancel(orderID)
-    }
+    this.createLimitOrder(response, side, orderID, size, price, timeInForce)
 
     return response
   }
 
   /**
-   * Modify an existing order with given ID
+   * Modify an existing order with given ID. When an order is modified by price or quantity,
+   * it will be deemed as a new entry. Under the price-time-priority algorithm, orders are
+   * prioritized according to their order price and order time. Hence, the latest orders
+   * will be placed at the back of the matching order queue.
    *
    * @param orderID - The ID of the order to be modified
    * @param orderUpdate - An object with the modified size and/or price of an order. The shape of the object is `{size, price}`.
-   * @returns The modified order if exists or `undefined`
+   * @returns An object with the result of the processed order or an error
    */
   public modify = (
     orderID: string,
     orderUpdate: OrderUpdatePrice | OrderUpdateSize
-  ): Order | undefined => {
+  ): IProcessOrder => {
     const order = this.orders[orderID]
-    if (order === undefined) return
-
-    let updatedOrder: Order | undefined
-    if (order.side === Side.BUY) {
-      // Check if price is changed
-      if (
-        orderUpdate.price !== undefined &&
-        orderUpdate.price !== order.price
-      ) {
-        const newPrice = orderUpdate.price
-        // Check if the limit new price is equal or greater than the current ask price.
-        // If so we have to remove the previous order and create a new limit order
-        const lowerAsk = this.asks.minPriceQueue()
-        if (lowerAsk !== undefined && newPrice >= lowerAsk.price()) {
-          this.cancel(order.id)
-          const result = this.limit(
-            order.side,
-            order.id,
-            orderUpdate.size ?? order.size,
-            newPrice
-          )
-          updatedOrder = result.partial?.id === order.id ? result.partial : result.done[result.done.length - 1]
-        } else {
-          updatedOrder = this.bids.updateOrderPrice(order, {
-            size: orderUpdate.size,
-            price: newPrice
-          })
-        }
-      } else if (
-        orderUpdate.size !== undefined &&
-        orderUpdate.size !== order.size
-      ) {
-        // Quantity changed. Price is the same.
-        const newSize = orderUpdate.size
-        updatedOrder = this.bids.updateOrderSize(order, { ...orderUpdate, size: newSize })
-      }
-    } else {
-      // Check if price is changed
-      if (
-        orderUpdate.price !== undefined &&
-        orderUpdate.price !== order.price
-      ) {
-        const newPrice = orderUpdate.price
-        // Check if the new price is equal or lower than the current bid price.
-        // If so we have to remove the previous order and create a new limit order
-        const highestBid = this.bids.maxPriceQueue()
-        if (
-          highestBid !== undefined &&
-          newPrice <= highestBid.price()
-        ) {
-          this.cancel(order.id)
-          const result = this.limit(
-            order.side,
-            order.id,
-            orderUpdate.size ?? order.size,
-            newPrice
-          )
-          updatedOrder = result.partial?.id === order.id ? result.partial : result.done[result.done.length - 1]
-        } else {
-          updatedOrder = this.asks.updateOrderPrice(order, {
-            size: orderUpdate.size,
-            price: newPrice
-          })
-        }
-      } else if (
-        orderUpdate.size !== undefined &&
-        orderUpdate.size !== order.size
-      ) {
-        // Quantity changed. Price is the same.
-        const newSize = orderUpdate.size
-        updatedOrder = this.asks.updateOrderSize(order, { ...orderUpdate, size: newSize })
+    if (order === undefined) {
+      return {
+        done: [],
+        partial: null,
+        partialQuantityProcessed: 0,
+        quantityLeft: 0,
+        err: CustomError(ERROR.ErrOrderNotFound)
       }
     }
-    // is undefined when size and price are the same
-    if (updatedOrder != null) this.orders[orderID] = updatedOrder
-    return updatedOrder
+    if (orderUpdate?.price !== undefined || orderUpdate?.size !== undefined) {
+      const newPrice = orderUpdate.price ?? order.price
+      const newSize = orderUpdate.size ?? order.size
+      if (newPrice > 0 && newSize > 0) {
+        const response = this.responseShape(newSize)
+        this.cancel(order.id)
+        this.createLimitOrder(
+          response,
+          order.side,
+          order.id,
+          newSize,
+          newPrice,
+          TimeInForce.GTC
+        )
+        return response
+      }
+    }
+    // Missing one of price and/or size, or the provided ones are not greater than zero
+    return {
+      done: [],
+      partial: null,
+      partialQuantityProcessed: 0,
+      quantityLeft: orderUpdate?.size ?? 0,
+      err: CustomError(ERROR.ErrInvalidPriceOrQuantity)
+    }
   }
 
   /**
@@ -446,6 +316,113 @@ export class OrderBook {
     }
 
     return { price, err }
+  }
+
+  private readonly responseShape = (size: number): IProcessOrder => {
+    return {
+      done: [],
+      partial: null,
+      partialQuantityProcessed: 0,
+      quantityLeft: size,
+      err: null
+    }
+  }
+
+  private readonly createLimitOrder = (
+    response: IProcessOrder,
+    side: Side,
+    orderID: string,
+    size: number,
+    price: number,
+    timeInForce: TimeInForce
+  ): void => {
+    let quantityToTrade = size
+    let sideToProcess: OrderSide
+    let sideToAdd: OrderSide
+    let comparator
+    let iter
+
+    if (side === Side.BUY) {
+      sideToAdd = this.bids
+      sideToProcess = this.asks
+      comparator = this.greaterThanOrEqual
+      iter = this.asks.minPriceQueue
+    } else {
+      sideToAdd = this.asks
+      sideToProcess = this.bids
+      comparator = this.lowerThanOrEqual
+      iter = this.bids.maxPriceQueue
+    }
+
+    if (timeInForce === TimeInForce.FOK) {
+      const fillable = this.canFillOrder(sideToProcess, side, size, price)
+      if (!fillable) {
+        response.err = CustomError(ERROR.ErrLimitFOKNotFillable)
+        return
+      }
+    }
+
+    let bestPrice = iter()
+    while (
+      quantityToTrade > 0 &&
+      sideToProcess.len() > 0 &&
+      bestPrice !== undefined &&
+      comparator(price, bestPrice.price())
+    ) {
+      const { done, partial, partialQuantityProcessed, quantityLeft } =
+        this.processQueue(bestPrice, quantityToTrade)
+      response.done = response.done.concat(done)
+      response.partial = partial
+      response.partialQuantityProcessed = partialQuantityProcessed
+      quantityToTrade = quantityLeft
+      response.quantityLeft = quantityToTrade
+      bestPrice = iter()
+    }
+
+    if (quantityToTrade > 0) {
+      const order = new Order(
+        orderID,
+        side,
+        quantityToTrade,
+        price,
+        Date.now(),
+        true
+      )
+      if (response.done.length > 0) {
+        response.partialQuantityProcessed = size - quantityToTrade
+        response.partial = order
+      }
+      this.orders[orderID] = sideToAdd.append(order)
+    } else {
+      let totalQuantity = 0
+      let totalPrice = 0
+
+      response.done.forEach((order: Order) => {
+        totalQuantity += order.size
+        totalPrice += order.price * order.size
+      })
+
+      if (response.partialQuantityProcessed > 0 && response.partial !== null) {
+        totalQuantity += response.partialQuantityProcessed
+        totalPrice +=
+          response.partial.price * response.partialQuantityProcessed
+      }
+
+      response.done.push(
+        new Order(
+          orderID,
+          side,
+          size,
+          totalPrice / totalQuantity,
+          Date.now()
+        )
+      )
+    }
+
+    // If IOC order was not matched completely remove from the order book
+    if (timeInForce === TimeInForce.IOC && response.quantityLeft > 0) {
+      this.cancel(orderID)
+    }
   }
 
   private readonly greaterThanOrEqual = (a: number, b: number): boolean => {

--- a/src/orderside.ts
+++ b/src/orderside.ts
@@ -109,9 +109,9 @@ export class OrderSide {
     oldOrder: Order,
     orderUpdate: OrderUpdateSize
   ): Order => {
-    const newOrderPrize = orderUpdate.price ?? oldOrder.price
+    const newOrderPrice = orderUpdate.price ?? oldOrder.price
     this._volume += orderUpdate.size - oldOrder.size
-    this._total += orderUpdate.size * newOrderPrize - oldOrder.size * oldOrder.price
+    this._total += orderUpdate.size * newOrderPrice - oldOrder.size * oldOrder.price
     this._prices[oldOrder.price.toString()].updateOrderSize(oldOrder, orderUpdate.size)
     return oldOrder
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/fasenderos/hft-limit-order-book/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs (README.md) have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When an order is modified by `size` the order remain in the same position of the matching order queue.

Issue Number: #336 

## What is the new behavior?
When an order is modified by `size` the order will be deemed as a new entry. Under the price-time-priority algorithm, orders are prioritized according to their order price and order time. Hence, the latest orders will be placed at the back of the matching order queue.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The `modify` function now return an object with the `IProcessOrder` interface.
