### PR TITLE
Add takerQty and makerQty Properties to Orders, Replacing isMaker Flag

### DIFF
--- a/src/order.ts
+++ b/src/order.ts
@@ -18,13 +18,11 @@ abstract class BaseOrder {
   readonly _id: string
   readonly _side: Side
   _size: number
-  readonly _origSize: number
   _time: number
   constructor (options: OrderOptions) {
     this._id = options.id ?? randomUUID()
     this._side = options.side
     this._size = options.size
-    this._origSize = options.origSize ?? options.size
     this._time = options.time ?? Date.now()
   }
 
@@ -48,11 +46,6 @@ abstract class BaseOrder {
     this._size = size
   }
 
-  // Getter for the original size of the order
-  get origSize (): number {
-    return this._origSize
-  }
-
   // Getter for order timestamp
   get time (): number {
     return this._time
@@ -72,18 +65,22 @@ abstract class BaseOrder {
 }
 export class LimitOrder extends BaseOrder {
   private readonly _type: OrderType.LIMIT
+  readonly _origSize: number
   private _price: number
   private readonly _timeInForce: TimeInForce
-  private readonly _isMaker: boolean
+  private readonly _makerQty: number
+  private readonly _takerQty: number
   private readonly _postOnly: boolean
   // Refers to the linked Stop Limit order stopPrice
   private readonly _ocoStopPrice?: number
   constructor (options: InternalLimitOrderOptions) {
     super(options)
     this._type = options.type
+    this._origSize = options.origSize
     this._price = options.price
     this._timeInForce = options.timeInForce
-    this._isMaker = options.isMaker
+    this._makerQty = options.makerQty
+    this._takerQty = options.takerQty
     this._postOnly = options.postOnly ?? false
     this._ocoStopPrice = options.ocoStopPrice
   }
@@ -113,9 +110,19 @@ export class LimitOrder extends BaseOrder {
     return this._postOnly
   }
 
-  // Getter for order isMaker
-  get isMaker (): boolean {
-    return this._isMaker
+  // Getter for the original size of the order
+  get origSize (): number {
+    return this._origSize
+  }
+
+  // Getter for order makerQty
+  get makerQty (): number {
+    return this._makerQty
+  }
+
+  // Getter for order takerQty
+  get takerQty (): number {
+    return this._takerQty
   }
 
   get ocoStopPrice (): number | undefined {
@@ -131,7 +138,8 @@ export class LimitOrder extends BaseOrder {
     price: ${this._price}
     time: ${this._time}
     timeInForce: ${this._timeInForce}
-    isMaker: ${this._isMaker as unknown as string}`
+    makerQty: ${this._makerQty}
+    takerQty: ${this._takerQty}`
 
   toJSON = (): string => JSON.stringify(this.toObject())
 
@@ -144,7 +152,8 @@ export class LimitOrder extends BaseOrder {
     price: this._price,
     time: this._time,
     timeInForce: this._timeInForce,
-    isMaker: this._isMaker
+    makerQty: this._makerQty,
+    takerQty: this._takerQty
   })
 }
 
@@ -172,7 +181,6 @@ export class StopMarketOrder extends BaseOrder {
     type: ${this.type}
     side: ${this._side}
     size: ${this._size}
-    origSize: ${this._origSize}
     stopPrice: ${this._stopPrice}
     time: ${this._time}`
 
@@ -183,7 +191,6 @@ export class StopMarketOrder extends BaseOrder {
     type: this.type,
     side: this._side,
     size: this._size,
-    origSize: this._origSize,
     stopPrice: this._stopPrice,
     time: this._time
   })
@@ -194,7 +201,6 @@ export class StopLimitOrder extends BaseOrder {
   private _price: number
   private readonly _stopPrice: number
   private readonly _timeInForce: TimeInForce
-  private readonly _isMaker: boolean
   // It's true when there is a linked Limit Order
   private readonly _isOCO: boolean
   constructor (options: InternalStopLimitOrderOptions) {
@@ -203,7 +209,6 @@ export class StopLimitOrder extends BaseOrder {
     this._price = options.price
     this._stopPrice = options.stopPrice
     this._timeInForce = options.timeInForce
-    this._isMaker = options.isMaker
     this._isOCO = options.isOCO ?? false
   }
 
@@ -232,11 +237,6 @@ export class StopLimitOrder extends BaseOrder {
     return this._timeInForce
   }
 
-  // Getter for order isMaker
-  get isMaker (): boolean {
-    return this._isMaker
-  }
-
   // Getter for order isOCO
   get isOCO (): boolean {
     return this._isOCO
@@ -247,12 +247,10 @@ export class StopLimitOrder extends BaseOrder {
     type: ${this.type}
     side: ${this._side}
     size: ${this._size}
-    origSize: ${this._origSize}
     price: ${this._price}
     stopPrice: ${this._stopPrice}
     timeInForce: ${this._timeInForce}
-    time: ${this._time}
-    isMaker: ${this._isMaker as unknown as string}`
+    time: ${this._time}`
 
   toJSON = (): string => JSON.stringify(this.toObject())
 
@@ -261,12 +259,10 @@ export class StopLimitOrder extends BaseOrder {
     type: this.type,
     side: this._side,
     size: this._size,
-    origSize: this._origSize,
     price: this._price,
     stopPrice: this._stopPrice,
     timeInForce: this._timeInForce,
-    time: this._time,
-    isMaker: this._isMaker
+    time: this._time
   })
 }
 

--- a/src/orderside.ts
+++ b/src/orderside.ts
@@ -92,16 +92,10 @@ export class OrderSide {
   ): LimitOrder => {
     this.remove(oldOrder)
     const newOrder = OrderFactory.createOrder({
-      id: oldOrder.id,
-      type: oldOrder.type,
-      side: oldOrder.side,
+      ...oldOrder.toObject(),
       size: orderUpdate.size !== undefined ? orderUpdate.size : oldOrder.size,
-      origSize: oldOrder.origSize,
       price: orderUpdate.price,
-      time: Date.now(),
-      timeInForce: oldOrder.timeInForce,
-      postOnly: oldOrder.postOnly,
-      isMaker: oldOrder.isMaker
+      time: Date.now()
     })
     this.append(newOrder)
     return newOrder

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,6 @@ interface BaseOrderOptions {
 interface InternalBaseOrderOptions extends BaseOrderOptions {
   type: OrderType
   time?: number
-  origSize?: number
 }
 /**
  * Specific options for a market order.
@@ -50,10 +49,12 @@ interface ILimitOrderOptions extends InternalBaseOrderOptions {
   id: string
   price: number
   timeInForce: TimeInForce
-  isMaker: boolean
 }
 export interface InternalLimitOrderOptions extends ILimitOrderOptions {
   type: OrderType.LIMIT
+  origSize: number
+  makerQty: number
+  takerQty: number
   postOnly?: boolean
   ocoStopPrice?: number
 }
@@ -107,14 +108,15 @@ export interface IMarketOrder {
  */
 export interface ILimitOrder {
   id: string
-  type: OrderType
+  type: OrderType.LIMIT
   side: Side
   size: number
   origSize: number
   price: number
   time: number
   timeInForce: TimeInForce
-  isMaker: boolean
+  takerQty: number
+  makerQty: number
 }
 
 /**
@@ -125,7 +127,6 @@ export interface IStopMarketOrder {
   type: OrderType
   side: Side
   size: number
-  origSize: number
   stopPrice: number
   time: number
 }
@@ -138,12 +139,10 @@ export interface IStopLimitOrder {
   type: OrderType
   side: Side
   size: number
-  origSize: number
   price: number
   stopPrice: number
   timeInForce: TimeInForce
   time: number
-  isMaker: boolean
 }
 
 /**

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -26,9 +26,11 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
       side,
       size,
       price,
+      origSize: size,
       time,
       timeInForce,
-      isMaker: false
+      makerQty: size,
+      takerQty: 0
     })
 
     equal(order instanceof LimitOrder, true)
@@ -40,7 +42,8 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
     equal(order.price, price)
     equal(order.time, time)
     equal(order.timeInForce, timeInForce)
-    equal(order.isMaker, false)
+    equal(order.makerQty, size)
+    equal(order.takerQty, 0)
     equal(order.ocoStopPrice, undefined)
     same(order.toObject(), {
       id,
@@ -51,7 +54,8 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
       price,
       time,
       timeInForce,
-      isMaker: order.isMaker
+      makerQty: size,
+      takerQty: 0
     })
     equal(
       order.toString(),
@@ -63,7 +67,8 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
     price: ${price}
     time: ${time}
     timeInForce: ${timeInForce}
-    isMaker: ${false as unknown as string}`
+    makerQty: ${size}
+    takerQty: 0`
     )
     equal(
       order.toJSON(),
@@ -76,7 +81,8 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
         price,
         time,
         timeInForce,
-        isMaker: false
+        makerQty: size,
+        takerQty: 0
       })
     )
   }
@@ -90,9 +96,11 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
       side,
       size,
       price,
+      origSize: size,
       time,
       timeInForce,
-      isMaker: false,
+      makerQty: size,
+      takerQty: 0,
       ocoStopPrice
     })
     equal(order instanceof LimitOrder, true)
@@ -104,7 +112,8 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
     equal(order.price, price)
     equal(order.time, time)
     equal(order.timeInForce, timeInForce)
-    equal(order.isMaker, false)
+    equal(order.makerQty, size)
+    equal(order.takerQty, 0)
     equal(order.ocoStopPrice, ocoStopPrice)
     same(order.toObject(), {
       id,
@@ -115,7 +124,8 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
       price,
       time,
       timeInForce,
-      isMaker: order.isMaker
+      makerQty: size,
+      takerQty: 0
     })
     equal(
       order.toString(),
@@ -127,7 +137,8 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
     price: ${price}
     time: ${time}
     timeInForce: ${timeInForce}
-    isMaker: ${false as unknown as string}`
+    makerQty: ${size}
+    takerQty: 0`
     )
     equal(
       order.toJSON(),
@@ -140,7 +151,8 @@ void test('it should create LimitOrder', ({ equal, same, end }) => {
         price,
         time,
         timeInForce,
-        isMaker: false
+        makerQty: size,
+        takerQty: 0
       })
     )
   }
@@ -168,7 +180,6 @@ void test('it should create StopMarketOrder', ({ equal, same, end }) => {
   equal(order.type, type)
   equal(order.side, side)
   equal(order.size, size)
-  equal(order.origSize, size)
   equal(order.stopPrice, stopPrice)
   equal(order.time, time)
   same(order.toObject(), {
@@ -176,7 +187,6 @@ void test('it should create StopMarketOrder', ({ equal, same, end }) => {
     type,
     side,
     size,
-    origSize: size,
     stopPrice,
     time
   })
@@ -186,7 +196,6 @@ void test('it should create StopMarketOrder', ({ equal, same, end }) => {
     type: ${type}
     side: ${side}
     size: ${size}
-    origSize: ${size}
     stopPrice: ${stopPrice}
     time: ${time}`
   )
@@ -197,7 +206,6 @@ void test('it should create StopMarketOrder', ({ equal, same, end }) => {
       type,
       side,
       size,
-      origSize: size,
       stopPrice,
       time
     })
@@ -223,8 +231,7 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
       price,
       time,
       stopPrice,
-      timeInForce,
-      isMaker: true
+      timeInForce
     })
 
     equal(order instanceof StopLimitOrder, true)
@@ -233,10 +240,8 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
     equal(order.side, side)
     equal(order.size, size)
     equal(order.price, price)
-    equal(order.origSize, size)
     equal(order.stopPrice, stopPrice)
     equal(order.timeInForce, timeInForce)
-    equal(order.isMaker, true)
     equal(order.time, time)
     equal(order.isOCO, false)
     same(order.toObject(), {
@@ -244,12 +249,10 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
       type,
       side,
       size,
-      origSize: size,
       price,
       stopPrice,
       timeInForce,
-      time,
-      isMaker: true
+      time
     })
     equal(
       order.toString(),
@@ -257,12 +260,10 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
     type: ${type}
     side: ${side}
     size: ${size}
-    origSize: ${size}
     price: ${price}
     stopPrice: ${stopPrice}
     timeInForce: ${timeInForce}
-    time: ${time}
-    isMaker: ${true as unknown as string}`
+    time: ${time}`
     )
     equal(
       order.toJSON(),
@@ -271,12 +272,10 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
         type,
         side,
         size,
-        origSize: size,
         price,
         stopPrice,
         timeInForce,
-        time,
-        isMaker: true
+        time
       })
     )
     // Price setter
@@ -296,7 +295,6 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
       time,
       stopPrice,
       timeInForce,
-      isMaker: true,
       isOCO: true
     })
 
@@ -306,10 +304,8 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
     equal(order.side, side)
     equal(order.size, size)
     equal(order.price, price)
-    equal(order.origSize, size)
     equal(order.stopPrice, stopPrice)
     equal(order.timeInForce, timeInForce)
-    equal(order.isMaker, true)
     equal(order.time, time)
     equal(order.isOCO, true)
     same(order.toObject(), {
@@ -317,12 +313,10 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
       type,
       side,
       size,
-      origSize: size,
       price,
       stopPrice,
       timeInForce,
-      time,
-      isMaker: true
+      time
     })
     equal(
       order.toString(),
@@ -330,12 +324,10 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
     type: ${type}
     side: ${side}
     size: ${size}
-    origSize: ${size}
     price: ${price}
     stopPrice: ${stopPrice}
     timeInForce: ${timeInForce}
-    time: ${time}
-    isMaker: ${true as unknown as string}`
+    time: ${time}`
     )
     equal(
       order.toJSON(),
@@ -344,12 +336,10 @@ void test('it should create StopLimitOrder', ({ equal, same, end }) => {
         type,
         side,
         size,
-        origSize: size,
         price,
         stopPrice,
         timeInForce,
-        time,
-        isMaker: true
+        time
       })
     )
     // Price setter
@@ -398,7 +388,6 @@ void test('it should create order without passing a date or id', ({
     type,
     side,
     size,
-    origSize: size,
     stopPrice,
     time: fakeTimestamp
   })
@@ -408,7 +397,6 @@ void test('it should create order without passing a date or id', ({
     type: ${type}
     side: ${side}
     size: ${size}
-    origSize: ${size}
     stopPrice: ${stopPrice}
     time: ${fakeTimestamp}`
   )
@@ -420,7 +408,6 @@ void test('it should create order without passing a date or id', ({
       type,
       side,
       size,
-      origSize: size,
       stopPrice,
       time: fakeTimestamp
     })
@@ -442,9 +429,11 @@ void test('test orders setters', (t) => {
     side,
     size,
     price,
+    origSize: size,
     time,
     timeInForce,
-    isMaker: false
+    makerQty: size,
+    takerQty: 0
   })
 
   // Price setter
@@ -485,8 +474,7 @@ void test('test invalid order type', (t) => {
       size,
       price,
       time,
-      timeInForce,
-      isMaker: false
+      timeInForce
     })
   } catch (error) {
     if (error instanceof Error) {

--- a/test/orderbook.test.ts
+++ b/test/orderbook.test.ts
@@ -103,9 +103,18 @@ void test('test limit', ({ equal, end }) => {
   equal(ob.marketPrice, 100)
   equal(process1.err === null, true)
   equal(process1.done[0].id, 'order-b100')
+  equal((process1.done[0] as LimitOrder).makerQty, 0)
+  equal((process1.done[0] as LimitOrder).takerQty, 1)
+  equal((process1.done[0] as LimitOrder).makerQty + (process1.done[0] as LimitOrder).takerQty, (process1.done[0] as LimitOrder).origSize)
+
   equal(process1.partial?.id, 'sell-100')
-  equal((process1.partial as LimitOrder)?.isMaker, true)
+  equal(process1.partial?.origSize, 2)
+  equal(process1.partial?.size, 1)
+  equal(process1.partial?.takerQty, 0)
+  equal(process1.partial?.makerQty, 2)
   equal(process1.partialQuantityProcessed, 1)
+  equal(process1.quantityLeft, 0)
+  equal(process1.partialQuantityProcessed + process1.quantityLeft, (process1.done[0] as LimitOrder).origSize)
 
   const process2 =
     // { done, partial, partialQuantityProcessed, quantityLeft, err } =
@@ -113,8 +122,16 @@ void test('test limit', ({ equal, end }) => {
   equal(process2.err === null, true)
   equal(process2.done.length, 5)
   equal(process2.partial?.id, 'order-b150')
-  equal((process2.partial as LimitOrder)?.isMaker, false)
+  equal((process2.partial as LimitOrder)?.origSize, 10)
+  equal((process2.partial as LimitOrder)?.size, 1)
+  equal((process2.partial as LimitOrder)?.takerQty, 9)
+  equal((process2.partial as LimitOrder)?.makerQty, 1)
+  equal(
+    (process2.partial as LimitOrder)?.takerQty + (process2.partial as LimitOrder)?.makerQty, (process2.partial as LimitOrder)?.origSize
+  )
   equal(process2.partialQuantityProcessed, 9)
+  equal(process2.quantityLeft, 1)
+  equal(process2.partialQuantityProcessed + process2.quantityLeft, (process2.partial as LimitOrder)?.origSize)
 
   const process3 = ob.limit({
     side: Side.SELL,

--- a/test/orderqueue.test.ts
+++ b/test/orderqueue.test.ts
@@ -17,8 +17,10 @@ void test('it should append/update/remove orders from queue', ({
     side: Side.SELL,
     size: 5,
     price,
+    origSize: 5,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 5,
+    takerQty: 0
   })
   const order2 = OrderFactory.createOrder({
     type: OrderType.LIMIT,
@@ -26,8 +28,10 @@ void test('it should append/update/remove orders from queue', ({
     side: Side.SELL,
     size: 5,
     price,
+    origSize: 5,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 5,
+    takerQty: 0
   })
 
   const head = oq.append(order1)
@@ -50,8 +54,10 @@ void test('it should append/update/remove orders from queue', ({
     side: Side.SELL,
     size: 10,
     price,
+    origSize: 10,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 10,
+    takerQty: 0
   })
 
   // Test update. Number of orders is always 2
@@ -86,8 +92,10 @@ void test('it should update order size and the volume', ({ equal, end }) => {
     side: Side.SELL,
     size: 5,
     price,
+    origSize: 5,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 5,
+    takerQty: 0
   })
   const order2 = OrderFactory.createOrder({
     type: OrderType.LIMIT,
@@ -95,8 +103,10 @@ void test('it should update order size and the volume', ({ equal, end }) => {
     side: Side.SELL,
     size: 5,
     price,
+    origSize: 5,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 5,
+    takerQty: 0
   })
 
   oq.append(order1)

--- a/test/orderside.test.ts
+++ b/test/orderside.test.ts
@@ -17,8 +17,10 @@ void test('it should append/update/remove orders from queue on BUY side', ({
     side: Side.BUY,
     size: 5,
     price: 10,
+    origSize: 5,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 5,
+    takerQty: 0
   })
   const order2 = OrderFactory.createOrder({
     type: OrderType.LIMIT,
@@ -26,8 +28,10 @@ void test('it should append/update/remove orders from queue on BUY side', ({
     side: Side.BUY,
     size: 5,
     price: 20,
+    origSize: 5,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 5,
+    takerQty: 0
   })
 
   equal(os.minPriceQueue() === undefined, true)
@@ -182,8 +186,10 @@ void test('it should append/update/remove orders from queue on SELL side', ({
     side: Side.SELL,
     size: 5,
     price: 10,
+    origSize: 5,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 5,
+    takerQty: 0
   })
   const order2 = OrderFactory.createOrder({
     type: OrderType.LIMIT,
@@ -191,8 +197,10 @@ void test('it should append/update/remove orders from queue on SELL side', ({
     side: Side.SELL,
     size: 5,
     price: 20,
+    origSize: 5,
     timeInForce: TimeInForce.GTC,
-    isMaker: true
+    makerQty: 5,
+    takerQty: 0
   })
 
   equal(os.minPriceQueue() === undefined, true)

--- a/test/stopbook.test.ts
+++ b/test/stopbook.test.ts
@@ -19,7 +19,6 @@ void test('it should add/remove/get order to stop book', ({ equal, same, end }) 
       size: 5,
       price: stopPrice,
       stopPrice,
-      isMaker: true,
       timeInForce: TimeInForce.GTC
     })
     ob.add(order)
@@ -115,7 +114,6 @@ void test('it should validate conditional order', ({ equal, end }) => {
       size: 5,
       ...(price !== null ? { price } : {}),
       stopPrice,
-      isMaker: true,
       timeInForce: TimeInForce.GTC
     }) as StopOrder
     equal(ob.validConditionalOrder(marketPrice, order), expect)

--- a/test/stopqueue.test.ts
+++ b/test/stopqueue.test.ts
@@ -22,8 +22,7 @@ void test('it should append/remove orders from queue', ({
     size: 5,
     price,
     stopPrice,
-    timeInForce: TimeInForce.GTC,
-    isMaker: true
+    timeInForce: TimeInForce.GTC
   })
   const order2 = OrderFactory.createOrder({
     type: OrderType.STOP_LIMIT,
@@ -32,8 +31,7 @@ void test('it should append/remove orders from queue', ({
     size: 5,
     price,
     stopPrice,
-    timeInForce: TimeInForce.GTC,
-    isMaker: true
+    timeInForce: TimeInForce.GTC
   })
 
   const head = oq.append(order1)
@@ -52,8 +50,7 @@ void test('it should append/remove orders from queue', ({
     size: 10,
     price,
     stopPrice,
-    timeInForce: TimeInForce.GTC,
-    isMaker: true
+    timeInForce: TimeInForce.GTC
   })
   oq.append(order3)
   equal(oq.len(), 3)
@@ -65,8 +62,7 @@ void test('it should append/remove orders from queue', ({
     size: 10,
     price,
     stopPrice,
-    timeInForce: TimeInForce.GTC,
-    isMaker: true
+    timeInForce: TimeInForce.GTC
   })
   oq.append(order4)
   equal(oq.len(), 4)

--- a/test/stopside.test.ts
+++ b/test/stopside.test.ts
@@ -22,7 +22,6 @@ void test('it should append/remove orders from queue on BUY side', ({
       size: 5,
       price: 10,
       timeInForce: TimeInForce.GTC,
-      isMaker: true,
       stopPrice: 10
     })
     os.append(order)
@@ -40,7 +39,6 @@ void test('it should append/remove orders from queue on BUY side', ({
       size: 5,
       price: 10,
       timeInForce: TimeInForce.GTC,
-      isMaker: true,
       stopPrice: 10 // same stopPrice as before, so same price level
     })
     os.append(order)
@@ -56,8 +54,7 @@ void test('it should append/remove orders from queue on BUY side', ({
       side: Side.BUY,
       size: 5,
       stopPrice: 20,
-      timeInForce: TimeInForce.GTC,
-      isMaker: true
+      timeInForce: TimeInForce.GTC
     })
 
     os.append(order)
@@ -139,7 +136,6 @@ void test('it should append/remove orders from queue on SELL side', ({
       size: 5,
       price: 10,
       timeInForce: TimeInForce.GTC,
-      isMaker: true,
       stopPrice: 10
     })
     os.append(order)
@@ -157,7 +153,6 @@ void test('it should append/remove orders from queue on SELL side', ({
       size: 5,
       price: 10,
       timeInForce: TimeInForce.GTC,
-      isMaker: true,
       stopPrice: 10 // same stopPrice as before, so same price level
     })
     os.append(order)
@@ -173,8 +168,7 @@ void test('it should append/remove orders from queue on SELL side', ({
       side: Side.SELL,
       size: 5,
       stopPrice: 20,
-      timeInForce: TimeInForce.GTC,
-      isMaker: true
+      timeInForce: TimeInForce.GTC
     })
 
     os.append(order)
@@ -251,7 +245,6 @@ void test('it should find all queue between upper and lower bound', ({
       size: 5,
       price: 10,
       timeInForce: TimeInForce.GTC,
-      isMaker: true,
       stopPrice
     })
     os.append(order)


### PR DESCRIPTION
This pull request introduces two new properties, `takerQty` and `makerQty`, to the `limit order` object. These properties provide a more detailed breakdown of the executed quantities of an order, allowing us to distinguish between the parts of the order that acted as a "taker" and those that acted as a "maker".

Previously, the order object included a boolean flag `isMaker`, which was set to true only if the order was completely a maker order. This approach did not account for partially executed orders, where part of the order could be a maker and part a taker.

The sum of `takerQty` and `makerQty` will always equal the original `size` of the order. This can be used to determine if the order was completely a `taker`, completely a `maker`, or a combination of both.

## Breaking Changes
- The `isMaker` property has been removed from the limit order object.
- New properties `takerQty` and `makerQty` have been added to the limit order objecct.